### PR TITLE
Fix Netlify production paths

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,11 @@
 publish = "frontend"
 functions = "netlify/functions"
 
+[functions]
+# Include the `data` directory in the deployed function bundle so the
+# `get-data` function can read the JSONC files at runtime.
+included_files = ["data/**"]
+
 [[redirects]]
 from = "/*"
 to = "/index.html"

--- a/netlify/functions/get-data.js
+++ b/netlify/functions/get-data.js
@@ -13,8 +13,18 @@ function parseJSONC(filePath) {
 
 exports.handler = async function(event, context) {
   try {
-    const modelsPath = path.join(__dirname, '..', '..', 'data', 'models.jsonc');
-    const quotesPath = path.join(__dirname, '..', '..', 'data', 'quotes.jsonc');
+    // When deployed on Netlify the function bundle is executed from the
+    // function's directory (e.g. `/var/task`). The `data` folder is packaged
+    // alongside the function (see `netlify.toml`). When running `netlify dev`
+    // locally, however, the working directory is the project root. We resolve
+    // the paths accordingly by first checking for the files relative to
+    // `__dirname` and falling back to the project root.
+    let modelsPath = path.join(__dirname, 'data', 'models.jsonc');
+    let quotesPath = path.join(__dirname, 'data', 'quotes.jsonc');
+    if (!fs.existsSync(modelsPath) || !fs.existsSync(quotesPath)) {
+      modelsPath = path.join(__dirname, '..', '..', 'data', 'models.jsonc');
+      quotesPath = path.join(__dirname, '..', '..', 'data', 'quotes.jsonc');
+    }
     const models = parseJSONC(modelsPath);
     const quotes = parseJSONC(quotesPath);
 


### PR DESCRIPTION
## Summary
- include the `data` directory in the Netlify function bundle
- resolve data file paths correctly in `get-data` for both local dev and production

## Testing
- `node - <<'EOF'
const handler = require('./netlify/functions/get-data.js').handler;
handler({}, {}).then(res=>console.log(res.statusCode, res.body)).catch(err=>console.error(err));
EOF`

------
https://chatgpt.com/codex/tasks/task_e_683f8161767483308b2d146a2c6d62fc